### PR TITLE
Introduce relaxed mode with less error checking

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -11,6 +11,7 @@ use attributes::{Attribute, Attributes};
 
 #[derive(Debug)]
 pub struct FontBuilder {
+    relaxed: bool,
     info: Option<Info>,
     common: Option<Common>,
     pages: Vec<String>,
@@ -21,17 +22,26 @@ pub struct FontBuilder {
 }
 
 impl FontBuilder {
-    pub fn build(mut self) -> crate::Result<Font> {
-        if let Some(specified) = self.char_count {
-            let realized = self.chars.len();
-            if specified as usize != realized {
-                return Err(Error::InvalidCharCount { specified, realized });
-            }
+    pub fn relaxed() -> Self {
+        Self {
+            relaxed: true,
+            ..Self::default()
         }
-        if let Some(specified) = self.kerning_count {
-            let realized = self.kernings.len();
-            if specified as usize != realized {
-                return Err(Error::InvalidKerningCount { specified, realized });
+    }
+
+    pub fn build(mut self) -> crate::Result<Font> {
+        if !self.relaxed {
+            if let Some(specified) = self.char_count {
+                let realized = self.chars.len();
+                if specified as usize != realized {
+                    return Err(Error::InvalidCharCount { specified, realized });
+                }
+            }
+            if let Some(specified) = self.kerning_count {
+                let realized = self.kernings.len();
+                if specified as usize != realized {
+                    return Err(Error::InvalidKerningCount { specified, realized });
+                }
             }
         }
         let info = self.info.take().ok_or(Error::NoInfoBlock)?;
@@ -128,6 +138,7 @@ impl FontBuilder {
 impl Default for FontBuilder {
     fn default() -> Self {
         Self {
+            relaxed: false,
             info: Option::None,
             common: Option::None,
             pages: Vec::default(),

--- a/src/text/load.rs
+++ b/src/text/load.rs
@@ -57,6 +57,16 @@ pub fn from_bytes(bytes: &[u8]) -> crate::Result<Font> {
     FontBuilderFnt::default().load_bytes(bytes)?.build()
 }
 
+/// Load text format font with relaxed constraints check.
+///
+/// This function is similar to [from_bytes], but it allows somewhat malformed files
+/// to still be loaded. For example when the specified character count differs from
+/// the actual amount of characters in file it will load all of them and not return
+/// an error.
+pub fn from_bytes_relaxed(bytes: &[u8]) -> crate::Result<Font> {
+    FontBuilderFnt::relaxed().load_bytes(bytes)?.build()
+}
+
 /// Read text format font.
 ///
 /// Read a font from the specified text format reader.
@@ -91,6 +101,10 @@ pub struct FontBuilderFnt {
 }
 
 impl FontBuilderFnt {
+    pub fn relaxed() -> Self {
+        Self { builder: FontBuilder::relaxed() }
+    }
+
     pub fn load_bytes(mut self, bytes: &[u8]) -> crate::Result<FontBuilder> {
         let mut attributes = TaggedAttributes::from_bytes(bytes);
         while let Some(Tag { tag, line }) = attributes.next_tag()? {

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -3,5 +3,5 @@
 mod load;
 mod store;
 
-pub use load::{from_bytes, from_reader, from_str};
+pub use load::{from_bytes, from_bytes_relaxed, from_reader, from_str};
 pub use store::{to_string, to_vec, to_writer};


### PR DESCRIPTION
Hi, thank you for your work!

There are files in the wild where the specified character count differs from the actual amount of characters and other bmfont parsers tend to not check this and load all characters regardless. This PR introduces (in a backwards compatible manner) the relaxed mode into this crate to allow bypassing those checks.